### PR TITLE
Fix lightbox reload opacity issue

### DIFF
--- a/lightbox.js
+++ b/lightbox.js
@@ -10,6 +10,9 @@ document.addEventListener('DOMContentLoaded', () => {
   function openLightbox(index) {
     currentIndex = index;
     imgEl.style.opacity = 0;
+    if (imgEl.src === galleryImgs[currentIndex].src) {
+      imgEl.removeAttribute('src');
+    }
     imgEl.src = galleryImgs[currentIndex].src;
     imgEl.onload = () => { imgEl.style.opacity = 1; };
     lightbox.classList.add('show');


### PR DESCRIPTION
## Summary
- ensure lightbox image opacity resets correctly when reopening the same image

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f6b9df1e88320963eb4ef0959c98e